### PR TITLE
build(deps): bump reveal-md and reveal.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "hasInstallScript": true,
             "dependencies": {
                 "replace-in-file": "^6.3.2",
-                "reveal-md": "^5.3.2"
+                "reveal-md": "^5.4.0"
             },
             "devDependencies": {
                 "cz-conventional-changelog": "^3.3.0",
@@ -77,21 +77,23 @@
             }
         },
         "node_modules/@commitlint/load": {
-            "version": "17.1.2",
-            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.1.2.tgz",
-            "integrity": "sha512-sk2p/jFYAWLChIfOIp/MGSIn/WzZ0vkc3afw+l4X8hGEYkvDe4gQUUAVxjl/6xMRn0HgnSLMZ04xXh5pkTsmgg==",
+            "version": "17.3.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.3.0.tgz",
+            "integrity": "sha512-u/pV6rCAJrCUN+HylBHLzZ4qj1Ew3+eN9GBPhNi9otGxtOfA8b+8nJSxaNbcC23Ins/kcpjGf9zPSVW7628Umw==",
             "dev": true,
             "optional": true,
             "dependencies": {
                 "@commitlint/config-validator": "^17.1.0",
                 "@commitlint/execute-rule": "^17.0.0",
-                "@commitlint/resolve-extends": "^17.1.0",
+                "@commitlint/resolve-extends": "^17.3.0",
                 "@commitlint/types": "^17.0.0",
                 "@types/node": "^14.0.0",
                 "chalk": "^4.1.0",
                 "cosmiconfig": "^7.0.0",
                 "cosmiconfig-typescript-loader": "^4.0.0",
-                "lodash": "^4.17.19",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.merge": "^4.6.2",
+                "lodash.uniq": "^4.5.0",
                 "resolve-from": "^5.0.0",
                 "ts-node": "^10.8.1",
                 "typescript": "^4.6.4"
@@ -177,16 +179,16 @@
             }
         },
         "node_modules/@commitlint/resolve-extends": {
-            "version": "17.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.1.0.tgz",
-            "integrity": "sha512-jqKm00LJ59T0O8O4bH4oMa4XyJVEOK4GzH8Qye9XKji+Q1FxhZznxMV/bDLyYkzbTodBt9sL0WLql8wMtRTbqQ==",
+            "version": "17.3.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.3.0.tgz",
+            "integrity": "sha512-Lf3JufJlc5yVEtJWC8o4IAZaB8FQAUaVlhlAHRACd0TTFizV2Lk2VH70et23KgvbQNf7kQzHs/2B4QZalBv6Cg==",
             "dev": true,
             "optional": true,
             "dependencies": {
                 "@commitlint/config-validator": "^17.1.0",
                 "@commitlint/types": "^17.0.0",
                 "import-fresh": "^3.0.0",
-                "lodash": "^4.17.19",
+                "lodash.mergewith": "^4.6.2",
                 "resolve-from": "^5.0.0",
                 "resolve-global": "^1.0.0"
             },
@@ -372,9 +374,9 @@
             "optional": true
         },
         "node_modules/@types/node": {
-            "version": "14.18.32",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.32.tgz",
-            "integrity": "sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow==",
+            "version": "14.18.34",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
+            "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==",
             "dev": true,
             "optional": true
         },
@@ -404,9 +406,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true,
             "optional": true,
             "bin": {
@@ -439,9 +441,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-            "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+            "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
             "dev": true,
             "optional": true,
             "dependencies": {
@@ -499,9 +501,9 @@
             }
         },
         "node_modules/anymatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -590,9 +592,9 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+            "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
             "dependencies": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.4",
@@ -602,7 +604,7 @@
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.10.3",
+                "qs": "6.11.0",
                 "raw-body": "2.5.1",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
@@ -1021,9 +1023,9 @@
             }
         },
         "node_modules/commitizen": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.5.tgz",
-            "integrity": "sha512-9sXju8Qrz1B4Tw7kC5KhnvwYQN88qs2zbiB8oyMsnXZyJ24PPGiNM3nHr73d32dnE3i8VJEXddBFIbOgYSEXtQ==",
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.6.tgz",
+            "integrity": "sha512-RyTM+EiD9GO01DJUn9MRRAet3XUHGfoUZoksLfr+1ym1Xt2q5EYJs9Fg2BtKSb5Mo53i0BtMBmWMHQXVlZ/L9w==",
             "dev": true,
             "dependencies": {
                 "cachedir": "2.3.0",
@@ -1161,9 +1163,9 @@
             "optional": true
         },
         "node_modules/cosmiconfig": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-            "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
             "dev": true,
             "optional": true,
             "dependencies": {
@@ -1178,9 +1180,9 @@
             }
         },
         "node_modules/cosmiconfig-typescript-loader": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.1.tgz",
-            "integrity": "sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz",
+            "integrity": "sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==",
             "dev": true,
             "optional": true,
             "engines": {
@@ -1486,13 +1488,13 @@
             }
         },
         "node_modules/express": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-            "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+            "version": "4.18.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+            "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.0",
+                "body-parser": "1.20.1",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "0.5.0",
@@ -1511,7 +1513,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "0.1.7",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.10.3",
+                "qs": "6.11.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "0.18.0",
@@ -1920,9 +1922,9 @@
             }
         },
         "node_modules/highlight.js": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.1.tgz",
-            "integrity": "sha512-LKzHqnxr4CrD2YsNoIf/o5nJ09j4yi/GcH5BnYz9UnVpZdS4ucMgvP61TDty5xJcFGRjnH4DpujkS9bHT3hq0Q==",
+            "version": "11.7.0",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.7.0.tgz",
+            "integrity": "sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ==",
             "engines": {
                 "node": ">=12.0.0"
             }
@@ -2264,9 +2266,9 @@
             }
         },
         "node_modules/is-installed-globally/node_modules/global-dirs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-            "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+            "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
             "dependencies": {
                 "ini": "2.0.0"
             },
@@ -2500,11 +2502,39 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true,
+            "optional": true
+        },
         "node_modules/lodash.map": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
             "integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==",
             "dev": true
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/lodash.mergewith": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+            "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+            "dev": true,
+            "optional": true
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -3059,31 +3089,82 @@
             }
         },
         "node_modules/patch-package": {
-            "version": "6.4.7",
-            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
-            "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.0.tgz",
+            "integrity": "sha512-tC3EqJmo74yKqfsMzELaFwxOAu6FH6t+FzFOsnWAuARm7/n2xB5AOeOueE221eM9gtMuIKMKpF9tBy/X2mNP0Q==",
             "dev": true,
             "dependencies": {
                 "@yarnpkg/lockfile": "^1.1.0",
-                "chalk": "^2.4.2",
+                "chalk": "^4.1.2",
                 "cross-spawn": "^6.0.5",
                 "find-yarn-workspace-root": "^2.0.0",
                 "fs-extra": "^7.0.1",
                 "is-ci": "^2.0.0",
                 "klaw-sync": "^6.0.0",
-                "minimist": "^1.2.0",
+                "minimist": "^1.2.6",
                 "open": "^7.4.2",
                 "rimraf": "^2.6.3",
                 "semver": "^5.6.0",
                 "slash": "^2.0.0",
-                "tmp": "^0.0.33"
+                "tmp": "^0.0.33",
+                "yaml": "^1.10.2"
             },
             "bin": {
                 "patch-package": "index.js"
             },
             "engines": {
+                "node": ">=10",
                 "npm": ">5"
             }
+        },
+        "node_modules/patch-package/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/patch-package/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/patch-package/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/patch-package/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "node_modules/patch-package/node_modules/fs-extra": {
             "version": "7.0.1",
@@ -3099,6 +3180,15 @@
                 "node": ">=6 <7 || >=8"
             }
         },
+        "node_modules/patch-package/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/patch-package/node_modules/jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -3106,6 +3196,18 @@
             "dev": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/patch-package/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/patch-package/node_modules/universalify": {
@@ -3241,7 +3343,7 @@
             "version": "1.20.0",
             "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
             "integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
-            "deprecated": "Version no longer supported. Upgrade to @latest",
+            "deprecated": "< 18.1.0 is no longer supported",
             "hasInstallScript": true,
             "optional": true,
             "dependencies": {
@@ -3268,9 +3370,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.10.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
             "dependencies": {
                 "side-channel": "^1.0.4"
             },
@@ -3528,25 +3630,25 @@
             }
         },
         "node_modules/reveal-md": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/reveal-md/-/reveal-md-5.3.4.tgz",
-            "integrity": "sha512-b0/HijfOPoypeHLD9hWKFTJREMDOUDvoPGftCrP0BU54R2vHL8sc+P0BaB/xRGOvFbyP/PyGCkwleiY0U8PMYg==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/reveal-md/-/reveal-md-5.4.0.tgz",
+            "integrity": "sha512-dbVA4qylRP14g0s2QSiPlxUgDFsvpQhUsT0QiNKEYDWvkgS6kVtA/XPbKSp55NuUXJ66qnrsNKKa4QRWaLxLaw==",
             "dependencies": {
                 "debug": "4.3.4",
-                "express": "4.18.1",
+                "express": "4.18.2",
                 "fs-extra": "10.1.0",
                 "glob": "8.0.3",
-                "highlight.js": "11.5.1",
+                "highlight.js": "11.7.0",
                 "livereload": "0.9.3",
                 "lodash": "4.17.21",
                 "mustache": "4.2.0",
                 "open": "8.4.0",
-                "reveal.js": "4.3.1",
+                "reveal.js": "4.4.0",
                 "serve-favicon": "2.5.0",
                 "try-require": "1.2.1",
                 "update-notifier": "5.1.0",
                 "yaml-front-matter": "4.1.1",
-                "yargs-parser": "21.0.1"
+                "yargs-parser": "21.1.1"
             },
             "bin": {
                 "reveal-md": "bin/reveal-md.js"
@@ -3598,9 +3700,9 @@
             }
         },
         "node_modules/reveal-md/node_modules/minimatch": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-            "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+            "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -3625,9 +3727,9 @@
             }
         },
         "node_modules/reveal.js": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-4.3.1.tgz",
-            "integrity": "sha512-1kyEnWeUkaCdBdX//XXq9dtBK95ppvIlSwlHelrP8/wrX6LcsYp4HT9WTFoFEOUBfVqkm8C2aHQ367o+UKfcxw==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-4.4.0.tgz",
+            "integrity": "sha512-jIV6C9V2NEUjGzU8L6dUFGpk1KJmq7/EzP2fOW67ggc2c0Cp/PdprWxZ9Qgp46F0T2ZWDCjQ1p3Ytzy5jA6a2w==",
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -3654,9 +3756,9 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "7.5.7",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-            "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.6.0.tgz",
+            "integrity": "sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==",
             "dev": true,
             "dependencies": {
                 "tslib": "^2.1.0"
@@ -4032,9 +4134,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
             "dev": true
         },
         "node_modules/type-fest": {
@@ -4076,9 +4178,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+            "version": "4.9.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
             "dev": true,
             "optional": true,
             "bin": {
@@ -4420,7 +4522,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true,
-            "optional": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -4438,9 +4539,9 @@
             }
         },
         "node_modules/yargs": {
-            "version": "17.6.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
-            "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+            "version": "17.6.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+            "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -4448,16 +4549,16 @@
                 "require-directory": "^2.1.1",
                 "string-width": "^4.2.3",
                 "y18n": "^5.0.5",
-                "yargs-parser": "^21.0.0"
+                "yargs-parser": "^21.1.1"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/yargs-parser": {
-            "version": "21.0.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-            "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "engines": {
                 "node": ">=12"
             }
@@ -4532,21 +4633,23 @@
             "optional": true
         },
         "@commitlint/load": {
-            "version": "17.1.2",
-            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.1.2.tgz",
-            "integrity": "sha512-sk2p/jFYAWLChIfOIp/MGSIn/WzZ0vkc3afw+l4X8hGEYkvDe4gQUUAVxjl/6xMRn0HgnSLMZ04xXh5pkTsmgg==",
+            "version": "17.3.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.3.0.tgz",
+            "integrity": "sha512-u/pV6rCAJrCUN+HylBHLzZ4qj1Ew3+eN9GBPhNi9otGxtOfA8b+8nJSxaNbcC23Ins/kcpjGf9zPSVW7628Umw==",
             "dev": true,
             "optional": true,
             "requires": {
                 "@commitlint/config-validator": "^17.1.0",
                 "@commitlint/execute-rule": "^17.0.0",
-                "@commitlint/resolve-extends": "^17.1.0",
+                "@commitlint/resolve-extends": "^17.3.0",
                 "@commitlint/types": "^17.0.0",
                 "@types/node": "^14.0.0",
                 "chalk": "^4.1.0",
                 "cosmiconfig": "^7.0.0",
                 "cosmiconfig-typescript-loader": "^4.0.0",
-                "lodash": "^4.17.19",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.merge": "^4.6.2",
+                "lodash.uniq": "^4.5.0",
                 "resolve-from": "^5.0.0",
                 "ts-node": "^10.8.1",
                 "typescript": "^4.6.4"
@@ -4610,16 +4713,16 @@
             }
         },
         "@commitlint/resolve-extends": {
-            "version": "17.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.1.0.tgz",
-            "integrity": "sha512-jqKm00LJ59T0O8O4bH4oMa4XyJVEOK4GzH8Qye9XKji+Q1FxhZznxMV/bDLyYkzbTodBt9sL0WLql8wMtRTbqQ==",
+            "version": "17.3.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.3.0.tgz",
+            "integrity": "sha512-Lf3JufJlc5yVEtJWC8o4IAZaB8FQAUaVlhlAHRACd0TTFizV2Lk2VH70et23KgvbQNf7kQzHs/2B4QZalBv6Cg==",
             "dev": true,
             "optional": true,
             "requires": {
                 "@commitlint/config-validator": "^17.1.0",
                 "@commitlint/types": "^17.0.0",
                 "import-fresh": "^3.0.0",
-                "lodash": "^4.17.19",
+                "lodash.mergewith": "^4.6.2",
                 "resolve-from": "^5.0.0",
                 "resolve-global": "^1.0.0"
             }
@@ -4768,9 +4871,9 @@
             "optional": true
         },
         "@types/node": {
-            "version": "14.18.32",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.32.tgz",
-            "integrity": "sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow==",
+            "version": "14.18.34",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
+            "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==",
             "dev": true,
             "optional": true
         },
@@ -4797,9 +4900,9 @@
             }
         },
         "acorn": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true,
             "optional": true
         },
@@ -4820,9 +4923,9 @@
             }
         },
         "ajv": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-            "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+            "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
             "dev": true,
             "optional": true,
             "requires": {
@@ -4864,9 +4967,9 @@
             }
         },
         "anymatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "requires": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -4932,9 +5035,9 @@
             }
         },
         "body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+            "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
             "requires": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.4",
@@ -4944,7 +5047,7 @@
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.10.3",
+                "qs": "6.11.0",
                 "raw-body": "2.5.1",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
@@ -5238,9 +5341,9 @@
             "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
         },
         "commitizen": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.5.tgz",
-            "integrity": "sha512-9sXju8Qrz1B4Tw7kC5KhnvwYQN88qs2zbiB8oyMsnXZyJ24PPGiNM3nHr73d32dnE3i8VJEXddBFIbOgYSEXtQ==",
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.6.tgz",
+            "integrity": "sha512-RyTM+EiD9GO01DJUn9MRRAet3XUHGfoUZoksLfr+1ym1Xt2q5EYJs9Fg2BtKSb5Mo53i0BtMBmWMHQXVlZ/L9w==",
             "dev": true,
             "requires": {
                 "cachedir": "2.3.0",
@@ -5357,9 +5460,9 @@
             "optional": true
         },
         "cosmiconfig": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-            "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
             "dev": true,
             "optional": true,
             "requires": {
@@ -5371,9 +5474,9 @@
             }
         },
         "cosmiconfig-typescript-loader": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.1.tgz",
-            "integrity": "sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz",
+            "integrity": "sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==",
             "dev": true,
             "optional": true,
             "requires": {}
@@ -5595,13 +5698,13 @@
             }
         },
         "express": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-            "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+            "version": "4.18.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+            "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
             "requires": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.0",
+                "body-parser": "1.20.1",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "0.5.0",
@@ -5620,7 +5723,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "0.1.7",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.10.3",
+                "qs": "6.11.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "0.18.0",
@@ -5950,9 +6053,9 @@
             "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
         },
         "highlight.js": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.1.tgz",
-            "integrity": "sha512-LKzHqnxr4CrD2YsNoIf/o5nJ09j4yi/GcH5BnYz9UnVpZdS4ucMgvP61TDty5xJcFGRjnH4DpujkS9bHT3hq0Q=="
+            "version": "11.7.0",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.7.0.tgz",
+            "integrity": "sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ=="
         },
         "homedir-polyfill": {
             "version": "1.0.3",
@@ -6199,9 +6302,9 @@
             },
             "dependencies": {
                 "global-dirs": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-                    "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+                    "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
                     "requires": {
                         "ini": "2.0.0"
                     }
@@ -6384,11 +6487,39 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true,
+            "optional": true
+        },
         "lodash.map": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
             "integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==",
             "dev": true
+        },
+        "lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true,
+            "optional": true
+        },
+        "lodash.mergewith": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+            "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+            "dev": true,
+            "optional": true
+        },
+        "lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+            "dev": true,
+            "optional": true
         },
         "log-symbols": {
             "version": "4.1.0",
@@ -6789,26 +6920,61 @@
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
         },
         "patch-package": {
-            "version": "6.4.7",
-            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
-            "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.0.tgz",
+            "integrity": "sha512-tC3EqJmo74yKqfsMzELaFwxOAu6FH6t+FzFOsnWAuARm7/n2xB5AOeOueE221eM9gtMuIKMKpF9tBy/X2mNP0Q==",
             "dev": true,
             "requires": {
                 "@yarnpkg/lockfile": "^1.1.0",
-                "chalk": "^2.4.2",
+                "chalk": "^4.1.2",
                 "cross-spawn": "^6.0.5",
                 "find-yarn-workspace-root": "^2.0.0",
                 "fs-extra": "^7.0.1",
                 "is-ci": "^2.0.0",
                 "klaw-sync": "^6.0.0",
-                "minimist": "^1.2.0",
+                "minimist": "^1.2.6",
                 "open": "^7.4.2",
                 "rimraf": "^2.6.3",
                 "semver": "^5.6.0",
                 "slash": "^2.0.0",
-                "tmp": "^0.0.33"
+                "tmp": "^0.0.33",
+                "yaml": "^1.10.2"
             },
             "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
                 "fs-extra": {
                     "version": "7.0.1",
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -6820,6 +6986,12 @@
                         "universalify": "^0.1.0"
                     }
                 },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
                 "jsonfile": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -6827,6 +6999,15 @@
                     "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.6"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
                     }
                 },
                 "universalify": {
@@ -6955,9 +7136,9 @@
             }
         },
         "qs": {
-            "version": "6.10.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
             "requires": {
                 "side-channel": "^1.0.4"
             }
@@ -7144,26 +7325,26 @@
             }
         },
         "reveal-md": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/reveal-md/-/reveal-md-5.3.4.tgz",
-            "integrity": "sha512-b0/HijfOPoypeHLD9hWKFTJREMDOUDvoPGftCrP0BU54R2vHL8sc+P0BaB/xRGOvFbyP/PyGCkwleiY0U8PMYg==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/reveal-md/-/reveal-md-5.4.0.tgz",
+            "integrity": "sha512-dbVA4qylRP14g0s2QSiPlxUgDFsvpQhUsT0QiNKEYDWvkgS6kVtA/XPbKSp55NuUXJ66qnrsNKKa4QRWaLxLaw==",
             "requires": {
                 "debug": "4.3.4",
-                "express": "4.18.1",
+                "express": "4.18.2",
                 "fs-extra": "10.1.0",
                 "glob": "8.0.3",
-                "highlight.js": "11.5.1",
+                "highlight.js": "11.7.0",
                 "livereload": "0.9.3",
                 "lodash": "4.17.21",
                 "mustache": "4.2.0",
                 "open": "8.4.0",
                 "puppeteer": "1.20.0",
-                "reveal.js": "4.3.1",
+                "reveal.js": "4.4.0",
                 "serve-favicon": "2.5.0",
                 "try-require": "1.2.1",
                 "update-notifier": "5.1.0",
                 "yaml-front-matter": "4.1.1",
-                "yargs-parser": "21.0.1"
+                "yargs-parser": "21.1.1"
             },
             "dependencies": {
                 "brace-expansion": {
@@ -7197,9 +7378,9 @@
                     }
                 },
                 "minimatch": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-                    "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+                    "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
                     "requires": {
                         "brace-expansion": "^2.0.1"
                     }
@@ -7217,9 +7398,9 @@
             }
         },
         "reveal.js": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-4.3.1.tgz",
-            "integrity": "sha512-1kyEnWeUkaCdBdX//XXq9dtBK95ppvIlSwlHelrP8/wrX6LcsYp4HT9WTFoFEOUBfVqkm8C2aHQ367o+UKfcxw=="
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-4.4.0.tgz",
+            "integrity": "sha512-jIV6C9V2NEUjGzU8L6dUFGpk1KJmq7/EzP2fOW67ggc2c0Cp/PdprWxZ9Qgp46F0T2ZWDCjQ1p3Ytzy5jA6a2w=="
         },
         "rimraf": {
             "version": "2.7.1",
@@ -7237,9 +7418,9 @@
             "dev": true
         },
         "rxjs": {
-            "version": "7.5.7",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-            "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.6.0.tgz",
+            "integrity": "sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==",
             "dev": true,
             "requires": {
                 "tslib": "^2.1.0"
@@ -7518,9 +7699,9 @@
             }
         },
         "tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
             "dev": true
         },
         "type-fest": {
@@ -7553,9 +7734,9 @@
             }
         },
         "typescript": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+            "version": "4.9.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
             "dev": true,
             "optional": true
         },
@@ -7798,8 +7979,7 @@
             "version": "1.10.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "yaml-front-matter": {
             "version": "4.1.1",
@@ -7811,9 +7991,9 @@
             }
         },
         "yargs": {
-            "version": "17.6.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
-            "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+            "version": "17.6.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+            "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
             "requires": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -7821,13 +8001,13 @@
                 "require-directory": "^2.1.1",
                 "string-width": "^4.2.3",
                 "y18n": "^5.0.5",
-                "yargs-parser": "^21.0.0"
+                "yargs-parser": "^21.1.1"
             }
         },
         "yargs-parser": {
-            "version": "21.0.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-            "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         },
         "yauzl": {
             "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
         "replace-in-file": "^6.3.2",
-        "reveal-md": "^5.3.2"
+        "reveal-md": "^5.4.0"
     },
     "devDependencies": {
         "cz-conventional-changelog": "^3.3.0",


### PR DESCRIPTION
Bumps reveal-md from 5.3.2 to 5.4.0, which importantly bumps reveal.js from 4.3.1 to 4.4.0. The newest version of reveal.js fixes an issue with printing slides with text that uses `class="r-fit-text"`. (See [#3120](https://github.com/hakimel/reveal.js/issues/3120).)